### PR TITLE
Features/presence and chat

### DIFF
--- a/lib/werewolf.ex
+++ b/lib/werewolf.ex
@@ -11,6 +11,9 @@ defmodule Werewolf do
       supervisor(Werewolf.Endpoint, []),
       # Start the Ecto repository
       supervisor(Werewolf.Repo, []),
+
+      supervisor(Werewolf.Presence, []),
+      
       # Here you could define other workers and supervisors as children
       # worker(Werewolf.Worker, [arg1, arg2, arg3]),
     ]

--- a/test/channels/room_channel_test.exs
+++ b/test/channels/room_channel_test.exs
@@ -1,0 +1,15 @@
+defmodule Werewolf.RoomChannelTest do
+  use Werewolf.ChannelCase
+
+  alias Werewolf.RoomChannel
+  alias Werewolf.UserSocket
+
+  setup do
+    {:ok, socket} = connect(UserSocket, %{"user" => "bilbo"})
+    {:ok, _, socket} = subscribe_and_join(socket, RoomChannel, "room:lobby")
+
+    {:ok, socket: socket}
+  end
+
+
+end

--- a/test/channels/room_channel_test.exs
+++ b/test/channels/room_channel_test.exs
@@ -11,4 +11,9 @@ defmodule Werewolf.RoomChannelTest do
     {:ok, socket: socket}
   end
 
+  test "message:new broadcasts to room:lobby", %{socket: socket} do
+    push socket, "message:new", "Hello!"
+    assert_broadcast "message:new", %{ body: "Hello!", user: "bilbo"}
+  end
+
 end

--- a/test/channels/room_channel_test.exs
+++ b/test/channels/room_channel_test.exs
@@ -6,10 +6,9 @@ defmodule Werewolf.RoomChannelTest do
 
   setup do
     {:ok, socket} = connect(UserSocket, %{"user" => "bilbo"})
-    {:ok, _, socket} = subscribe_and_join(socket, RoomChannel, "room:lobby")
+    {:ok, _, socket} = subscribe_and_join(socket, RoomChannel, "rooms:lobby")
 
     {:ok, socket: socket}
   end
-
 
 end

--- a/test/controllers/game_controller_test.exs
+++ b/test/controllers/game_controller_test.exs
@@ -30,13 +30,13 @@ defmodule Werewolf.GameControllerTest do
   test "shows chosen resource", %{conn: conn} do
     game = Repo.insert! %Game{}
     conn = get conn, game_path(conn, :show, game)
-    assert html_response(conn, 200) =~ "Show game"
+    assert html_response(conn, 200) =~ "Welcome to game"
   end
 
   test "finds Game by slug", %{conn: conn} do
     Repo.insert! %Game{slug: "asdf"}
     conn = get conn, game_path(conn, :show, "asdf")
-    assert html_response(conn, 200) =~ "Show game"
+    assert html_response(conn, 200) =~ "Welcome to game"
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/web/channels/presence.ex
+++ b/web/channels/presence.ex
@@ -1,0 +1,77 @@
+defmodule Werewolf.Presence do
+  @moduledoc """
+  Provides presence tracking to channels and processes.
+
+  See the [`Phoenix.Presence`](http://hexdocs.pm/phoenix/Phoenix.Presence.html)
+  docs for more details.
+
+  ## Usage
+
+  Presences can be tracked in your channel after joining:
+
+      defmodule Werewolf.MyChannel do
+        use Werewolf.Web, :channel
+        alias Werewolf.Presence
+
+        def join("some:topic", _params, socket) do
+          send(self, :after_join)
+          {:ok, assign(socket, :user_id, ...)}
+        end
+
+        def handle_info(:after_join, socket) do
+          {:ok, _} = Presence.track(socket, socket.assigns.user_id, %{
+            online_at: inspect(System.system_time(:seconds))
+          })
+          push socket, "presence_state", Presence.list(socket)
+          {:noreply, socket}
+        end
+      end
+
+  In the example above, `Presence.track` is used to register this
+  channel's process as a presence for the socket's user ID, with
+  a map of metadata. Next, the current presence list for
+  the socket's topic is pushed to the client as a `"presence_state"` event.
+
+  Finally, a diff of presence join and leave events will be sent to the
+  client as they happen in real-time with the "presence_diff" event.
+  See `Phoenix.Presence.list/2` for details on the presence datastructure.
+
+  ## Fetching Presence Information
+
+  The `fetch/2` callback is triggered when using `list/1`
+  and serves as a mechanism to fetch presence information a single time,
+  before broadcasting the information to all channel subscribers.
+  This prevents N query problems and gives you a single place to group
+  isolated data fetching to extend presence metadata.
+
+  The function receives a topic and map of presences and must return a
+  map of data matching the Presence datastructure:
+
+      %{"123" => %{metas: [%{status: "away", phx_ref: ...}],
+        "456" => %{metas: [%{status: "online", phx_ref: ...}]}
+
+  The `:metas` key must be kept, but you can extend the map of information
+  to include any additional information. For example:
+
+      def fetch(_topic, entries) do
+        query =
+          from u in User,
+            where: u.id in ^Map.keys(entries),
+            select: {u.id, u}
+
+        users = query |> Repo.all |> Enum.into(%{})
+
+        for {key, %{metas: metas}} <- entries, into: %{} do
+          {key, %{metas: metas, user: users[key]}}
+        end
+      end
+
+  The function above fetches all users from the database who
+  have registered presences for the given topic. The fetched
+  information is then extended with a `:user` key of the user's
+  information, while maintaining the required `:metas` field from the
+  original presence data.
+  """
+  use Phoenix.Presence, otp_app: :werewolf,
+                        pubsub_server: Werewolf.PubSub
+end

--- a/web/channels/room_channel.ex
+++ b/web/channels/room_channel.ex
@@ -1,7 +1,7 @@
 defmodule Werewolf.RoomChannel do
   use Werewolf.Web, :channel
 
-  def join("rooms:lobby", _payload, socket) do
+  def join(_room, _payload, socket) do
     {:ok, socket}
   end
 

--- a/web/channels/room_channel.ex
+++ b/web/channels/room_channel.ex
@@ -5,4 +5,13 @@ defmodule Werewolf.RoomChannel do
     {:ok, socket}
   end
 
+  def handle_in("message:new", message, socket) do
+    broadcast! socket, "message:new", %{
+      user: socket.assigns.user,
+      body: message,
+      timestamp: :os.system_time(:milli_seconds)
+    }
+    {:noreply, socket}
+  end
+
 end

--- a/web/channels/room_channel.ex
+++ b/web/channels/room_channel.ex
@@ -1,7 +1,9 @@
 defmodule Werewolf.RoomChannel do
   use Werewolf.Web, :channel
+  alias Werewolf.Presence
 
   def join(_room, _payload, socket) do
+    send(self, :after_join)
     {:ok, socket}
   end
 
@@ -11,6 +13,14 @@ defmodule Werewolf.RoomChannel do
       body: message,
       timestamp: :os.system_time(:milli_seconds)
     }
+    {:noreply, socket}
+  end
+
+  def handle_info(:after_join, socket) do
+    {:ok, _} = Presence.track(socket, socket.assigns.user, %{
+      online_at: :os.system_time(:milli_seconds)
+    })
+    push socket, "presence_state", Presence.list(socket)
     {:noreply, socket}
   end
 

--- a/web/channels/room_channel.ex
+++ b/web/channels/room_channel.ex
@@ -1,0 +1,8 @@
+defmodule Werewolf.RoomChannel do
+  use Werewolf.Web, :channel
+
+  def join("rooms:lobby", _payload, socket) do
+    {:ok, socket}
+  end
+
+end

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -2,7 +2,7 @@ defmodule Werewolf.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  # channel "rooms:*", Werewolf.RoomChannel
+  channel "rooms:*", Werewolf.RoomChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket
@@ -19,10 +19,10 @@ defmodule Werewolf.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(_params, socket) do
-    {:ok, socket}
+  def connect(%{"user" => user}, socket) do
+    {:ok, assign(socket, :user, user)}
   end
-
+  
   # Socket id's are topics that allow you to identify all sockets for a given user:
   #
   #     def id(socket), do: "users_socket:#{socket.assigns.user_id}"

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -18,7 +18,7 @@ import "phoenix_html"
 // Local files can be imported directly using relative
 // paths "./socket" or full ones "web/static/js/socket".
 
-import socket from "./socket"
+import "./socket"
 
 import $ from 'jquery'
 

--- a/web/static/js/socket.js
+++ b/web/static/js/socket.js
@@ -13,7 +13,7 @@ import {Socket} from "phoenix"
 
   socket.connect()
 
-  let channel = socket.channel("rooms:lobby", {})
+  let channel = socket.channel(`rooms:${window.gameSlug}`, {})
   channel.join()
     .receive("ok", resp => { console.log("Joined successfully", resp) })
     .receive("error", resp => { console.log("Unable to join", resp) })

--- a/web/static/js/socket.js
+++ b/web/static/js/socket.js
@@ -18,4 +18,32 @@ import {Socket} from "phoenix"
     .receive("ok", resp => { console.log("Joined successfully", resp) })
     .receive("error", resp => { console.log("Unable to join", resp) })
 
+  let messageInput = document.getElementById("NewMessage")
+
+  messageInput.addEventListener("keypress", (e) => {
+    if (e.keyCode == 13 && messageInput.value != "") {
+      channel.push("message:new", messageInput.value)
+      messageInput.value = ""
+    }
+  });
+  
+  let formatTimestamp = (timestamp) => {
+    let date = new Date(timestamp)
+    return date.toLocaleTimeString()
+  }
+
+  let messageList = document.getElementById("MessageList")
+  let renderMessage = (message) => {
+    let messageElement = document.createElement("li")
+    messageElement.innerHTML = `
+      <b>${message.user}</b>
+      <i>${formatTimestamp(message.timestamp)}</i>
+      <p>${message.body}</p>
+    `
+    messageList.appendChild(messageElement)
+    messageList.scrollTop = messageList.scrollHeight;
+  }
+
+  channel.on("message:new", message => renderMessage(message))
+
 })();

--- a/web/static/js/socket.js
+++ b/web/static/js/socket.js
@@ -5,58 +5,17 @@
 // and connect at the socket path in "lib/my_app/endpoint.ex":
 import {Socket} from "phoenix"
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+(function () {
 
-// When you connect, you'll often need to authenticate the client.
-// For example, imagine you have an authentication plug, `MyAuth`,
-// which authenticates the session and assigns a `:current_user`.
-// If the current user exists you can assign the user's token in
-// the connection for use in the layout.
-//
-// In your "web/router.ex":
-//
-//     pipeline :browser do
-//       ...
-//       plug MyAuth
-//       plug :put_user_token
-//     end
-//
-//     defp put_user_token(conn, _) do
-//       if current_user = conn.assigns[:current_user] do
-//         token = Phoenix.Token.sign(conn, "user socket", current_user.id)
-//         assign(conn, :user_token, token)
-//       else
-//         conn
-//       end
-//     end
-//
-// Now you need to pass this token to JavaScript. You can do so
-// inside a script tag in "web/templates/layout/app.html.eex":
-//
-//     <script>window.userToken = "<%= assigns[:user_token] %>";</script>
-//
-// You will need to verify the user token in the "connect/2" function
-// in "web/channels/user_socket.ex":
-//
-//     def connect(%{"token" => token}, socket) do
-//       # max_age: 1209600 is equivalent to two weeks in seconds
-//       case Phoenix.Token.verify(socket, "user socket", token, max_age: 1209600) do
-//         {:ok, user_id} ->
-//           {:ok, assign(socket, :user, user_id)}
-//         {:error, reason} ->
-//           :error
-//       end
-//     end
-//
-// Finally, pass the token on connect as below. Or remove it
-// from connect if you don't care about authentication.
+  if (!window.userName) { return; }
 
-socket.connect()
+  let socket = new Socket("/socket", {params: {user: window.userName}})
 
-// Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
-channel.join()
-  .receive("ok", resp => { console.log("Joined successfully", resp) })
-  .receive("error", resp => { console.log("Unable to join", resp) })
+  socket.connect()
 
-export default socket
+  let channel = socket.channel("rooms:lobby", {})
+  channel.join()
+    .receive("ok", resp => { console.log("Joined successfully", resp) })
+    .receive("error", resp => { console.log("Unable to join", resp) })
+
+})();

--- a/web/templates/game/show.html.eex
+++ b/web/templates/game/show.html.eex
@@ -1,14 +1,24 @@
-<h2>Show game</h2>
-
-<ul>
-
-  <li>
-    <strong>Slug:</strong>
-    <%= @game.slug %>
+<h2>Welcome to game: <%= @game.slug %></h2>
+<div class="row">
+  <div class="col-md-12 alert alert-info">
     <%= user_message(@user_name) %>
-  </li>
+  </div>
+  
+  <div class="col-md-8">
+    <h2>Chat Messages</h2>
+    <%= if @user_name do %>
+      <input type="text" id="NewMessage" placeholder="Type and press enter..." class="form-control">
+    <% end %>
+    <ul id="MessageList" class="list-unstyled"></ul>
+  </div>
 
-</ul>
+  <div  class="col-md-4">
+    <h2>Who’s Online</h2>
+    <ul id="UserList" class="list-unstyled">
+      <li>Loading online users...</li>
+    </ul>
+  </div>
+</div>
 
 <%= link "Edit", to: game_path(@conn, :edit, @game) %>
 <%= link "Back", to: game_path(@conn, :index) %>

--- a/web/templates/game/show.html.eex
+++ b/web/templates/game/show.html.eex
@@ -1,3 +1,7 @@
+<script type="text/javascript">
+   var userName = "<%= @user_name %>";
+</script>
+
 <h2>Welcome to game: <%= @game.slug %></h2>
 <div class="row">
   <div class="col-md-12 alert alert-info">

--- a/web/templates/game/show.html.eex
+++ b/web/templates/game/show.html.eex
@@ -1,5 +1,6 @@
 <script type="text/javascript">
    var userName = "<%= @user_name %>";
+   var gameSlug = "<%= @game.slug %>";
 </script>
 
 <h2>Welcome to game: <%= @game.slug %></h2>

--- a/web/views/game_view.ex
+++ b/web/views/game_view.ex
@@ -2,6 +2,6 @@ defmodule Werewolf.GameView do
   use Werewolf.Web, :view
 
   def user_message(nil), do: "You are really not logged in "
-  def user_message(name), do: name
+  def user_message(name), do: "Hello, #{name}"
 
 end


### PR DESCRIPTION
## Goals

Add chat functionality with list of users to each game.

## Implementation

Transmit the username and game slug to the client via interpolated global javascript variables
Setup a per game Phoenix channel, track users with Presence
Transmit chat messages via the channel and render to client.
