### PR TITLE
add a unique index on username

### DIFF
--- a/priv/repo/migrations/20160804023831_create_username_index.exs
+++ b/priv/repo/migrations/20160804023831_create_username_index.exs
@@ -1,0 +1,7 @@
+defmodule Werewolf.Repo.Migrations.CreateUsernameIndex do
+  use Ecto.Migration
+
+  def change do
+    create index(:users, [:name], unique: true)
+  end
+end


### PR DESCRIPTION
Goals
====

Avoid a conflict where multiple users are mapped to the same row in the database

Implementation
===========

Add a unique index on the `name` field on the users table