### PR TITLE
Spikes/persist game state in ets

### DIFF
--- a/lib/werewolf/gameplay.ex
+++ b/lib/werewolf/gameplay.ex
@@ -10,8 +10,8 @@ defmodule Werewolf.Gameplay do
   ]
 
   # CLIENT
-  def start_link(game_id) do
-    GenServer.start_link(__MODULE__, game_id, name: ref(game_id))
+  def start_link({tid, game_id}) do
+    GenServer.start_link(__MODULE__, {tid, game_id}, name: ref(:gameplay, game_id))
   end
 
   def join(game_id, player_id, pid) do
@@ -23,7 +23,7 @@ defmodule Werewolf.Gameplay do
   end
 
   # SERVER
-  def init(game_id, tid) do
+  def init({tid, game_id}) do
     saved_state = :ets.lookup(tid, :game) |> initial_state(game_id)
     {:ok, {tid, saved_state}}
   end
@@ -32,27 +32,25 @@ defmodule Werewolf.Gameplay do
     %__MODULE__{id: game_id}
   end
 
-  def initial_state(state, _game_id) do
+  def initial_state([{_, state} | _], _game_id) do
     state
   end
 
   def handle_call({:join, player_id, _pid}, _from, {tid, game}) do
     updated_players = Enum.dedup(game.players ++ [player_id])
     game = %{game | players: updated_players}
-    |> IO.inspect
-    :ets.insert(:game, game)
-    {:reply, {:ok, self}, {tid, game}}
+    :ets.insert(tid, {:game, game})
+    {:reply, {:ok, self, game}, {tid, game}}
   end
 
   def handle_call({:start_game, _pid}, _from, {tid, game}) do
     new_game = %{game | game_started: true}
-    |> IO.inspect
-    :ets.insert(:game, new_game)
+    :ets.insert(tid, {:game, new_game})
     {:reply, {:ok, self}, {tid, new_game}}
   end
 
   defp try_call(game_id, message) do
-    case GenServer.whereis(ref(game_id)) do
+    case GenServer.whereis(ref(:gameplay, String.to_atom(game_id))) do
       nil ->
         {:error, "Game does not exist"}
       pid ->

--- a/lib/werewolf/gameplay.ex
+++ b/lib/werewolf/gameplay.ex
@@ -1,5 +1,7 @@
 defmodule Werewolf.Gameplay do
   use GenServer
+  alias Werewolf.{GameplayHelper}
+  import GameplayHelper
 
   defstruct [
     id: nil,
@@ -48,8 +50,6 @@ defmodule Werewolf.Gameplay do
     :ets.insert(:game, new_game)
     {:reply, {:ok, self}, {tid, new_game}}
   end
-
-  defp ref(game_id), do: {:global, {:gameplay, game_id}}
 
   defp try_call(game_id, message) do
     case GenServer.whereis(ref(game_id)) do

--- a/lib/werewolf/gameplay/gameplay_helper.ex
+++ b/lib/werewolf/gameplay/gameplay_helper.ex
@@ -1,3 +1,3 @@
 defmodule Werewolf.GameplayHelper do
-  def ref(game_id), do: {:global, {:gameplay, game_id}}
+  def ref(category, game_id), do: {:global, {category, game_id}}
 end

--- a/lib/werewolf/gameplay/gameplay_helper.ex
+++ b/lib/werewolf/gameplay/gameplay_helper.ex
@@ -1,0 +1,3 @@
+defmodule Werewolf.GameplayHelper do
+  def ref(game_id), do: {:global, {:gameplay, game_id}}
+end

--- a/lib/werewolf/gameplay/persister.ex
+++ b/lib/werewolf/gameplay/persister.ex
@@ -1,15 +1,18 @@
 defmodule Werewolf.Gameplay.Persister do
   use Supervisor
-  alias Werewolf.{Gameplay}
+  alias Werewolf.{Gameplay, GameplayHelper}
+  import GameplayHelper
 
   def init(game_id) do
-    IO.inspect(game_id)
     tid = :ets.new(game_id, [:set])
-    IO.inspect(tid)
     children = [
       worker(Gameplay, [[game_id, tid]], restart: :transient)
     ]
+    supervise(children, strategy: :one_for_one)
+  end
 
-    supervise(children, strategy: :simple_one_for_one)
+
+  def start_link(game_id) do
+    Supervisor.start_link(__MODULE__, game_id, name: ref(game_id))
   end
 end

--- a/lib/werewolf/gameplay/persister.ex
+++ b/lib/werewolf/gameplay/persister.ex
@@ -1,0 +1,15 @@
+defmodule Werewolf.Gameplay.Persister do
+  use Supervisor
+  alias Werewolf.{Gameplay}
+
+  def init(game_id) do
+    IO.inspect(game_id)
+    tid = :ets.new(game_id, [:set])
+    IO.inspect(tid)
+    children = [
+      worker(Gameplay, [[game_id, tid]], restart: :transient)
+    ]
+
+    supervise(children, strategy: :simple_one_for_one)
+  end
+end

--- a/lib/werewolf/gameplay/persister.ex
+++ b/lib/werewolf/gameplay/persister.ex
@@ -4,15 +4,15 @@ defmodule Werewolf.Gameplay.Persister do
   import GameplayHelper
 
   def init(game_id) do
-    tid = :ets.new(game_id, [:set])
+    tid = :ets.new(game_id, [:set, :public])
     children = [
-      worker(Gameplay, [[game_id, tid]], restart: :transient)
+      worker(Gameplay, [{tid, game_id}], restart: :transient)
     ]
     supervise(children, strategy: :one_for_one)
   end
 
 
   def start_link(game_id) do
-    Supervisor.start_link(__MODULE__, game_id, name: ref(game_id))
+    Supervisor.start_link(__MODULE__, game_id, name: ref(:persister, game_id))
   end
 end

--- a/lib/werewolf/gameplay/supervisor.ex
+++ b/lib/werewolf/gameplay/supervisor.ex
@@ -13,7 +13,7 @@ defmodule Werewolf.Gameplay.Supervisor do
   end
 
   def create_game(id) do
-    persister = Supervisor.start_child(__MODULE__, [id])
+    {_, persister} = Supervisor.start_child(__MODULE__, [id])
     [ game_pid | other_children ] = Supervisor.which_children(persister)
     game_pid
   end

--- a/lib/werewolf/gameplay/supervisor.ex
+++ b/lib/werewolf/gameplay/supervisor.ex
@@ -1,22 +1,28 @@
 defmodule Werewolf.Gameplay.Supervisor do
   use Supervisor
-  alias Werewolf.{Gameplay}
+  alias Werewolf.Gameplay.{Persister}
 
   def start_link, do: Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
 
   def init(:ok) do
     children = [
-      worker(Gameplay, [], restart: :temporary)
+      worker(Persister, [], restart: :temporary)
     ]
 
     supervise(children, strategy: :simple_one_for_one)
   end
 
-  def create_game(id), do: Supervisor.start_child(__MODULE__, [id])
+  def create_game(id) do
+    persister = Supervisor.start_child(__MODULE__, [id])
+    [ game_pid | other_children ] = Supervisor.which_children(persister)
+    game_pid
+  end
 
   def current_games do
     __MODULE__
     |> Supervisor.which_children
+    |> Enum.map(&Supervisor.which_children/1)
+    |> List.flatten
     |> Enum.map(&game_data/1)
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "combine": {:hex, :combine, "0.9.1", "5fd778ee77032ae593bf79aedb8519d9e36283e4f869abd98c2d6029ca476db8", [:mix], []},
   "comeonin": {:hex, :comeonin, "2.6.0", "74c288338b33205f9ce97e2117bb9a2aaab103a1811d243443d76fdb62f904ac", [:make, :make, :mix], []},
   "connection": {:hex, :connection, "1.0.3", "3145f7416be3df248a4935f24e3221dc467c1e3a158d62015b35bd54da365786", [:mix], []},
-  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "db_connection": {:hex, :db_connection, "1.0.0-rc.3", "d9ceb670fe300271140af46d357b669983cd16bc0d01206d7d3222dde56cf038", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
@@ -26,7 +26,7 @@
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "postgrex": {:hex, :postgrex, "0.11.2", "139755c1359d3c5c6d6e8b1ea72556d39e2746f61c6ddfb442813c91f53487e8", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
   "timex": {:hex, :timex, "2.2.1", "0d69012a7fd69f4cbdaa00cc5f2a5f30f1bed56072fb362ed4bddf60db343022", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
   "tzdata": {:hex, :tzdata, "0.5.8", "a4ffe564783c6519e4df230a5d0e1cf44b7db7f576bcae76d05540b5da5b6143", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]},
   "wallaby": {:hex, :wallaby, "0.7.0", "48278d1def9729f98f3b07b45dd8713b21acb6c9ad3fd3f37647ca955dfd4398", [:mix], [{:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:poison, ">= 1.4.0", [hex: :poison, optional: false]}, {:httpoison, "~> 0.8", [hex: :httpoison, optional: false]}]}}

--- a/web/channels/game_channel.ex
+++ b/web/channels/game_channel.ex
@@ -11,9 +11,9 @@ defmodule Werewolf.GameChannel do
   def game_join(socket, game_id) do
     player_id = socket.assigns.user
     case Gameplay.join(game_id, player_id, socket.channel_pid) do
-      {:ok, _pid} ->
+      {:ok, _pid, game_state} ->
         send(self, :after_join)
-        {:ok, socket}
+        {:ok, game_state, socket}
       {:error, reason} ->
         {:error, %{reason: reason}}
     end

--- a/web/controllers/game_create_controller.ex
+++ b/web/controllers/game_create_controller.ex
@@ -19,7 +19,9 @@ defmodule Werewolf.GameCreateController do
   end
 
   defp start_game(conn, game) do
-    Werewolf.Gameplay.Supervisor.create_game(game.slug)
+    game.slug
+    |> String.to_atom
+    |> Werewolf.Gameplay.Supervisor.create_game
     conn
   end
 

--- a/web/static/js/socket.js
+++ b/web/static/js/socket.js
@@ -14,8 +14,14 @@ import {Socket, Presence} from "phoenix"
   socket.connect()
 
   let channel = socket.channel(`games:${window.gameSlug}`, {})
+  let onJoin = (state) => { 
+    if (state.game_started) {
+      startGameUI();
+    }
+  };
+  
   channel.join()
-    .receive("ok", resp => { console.log("Joined successfully", resp) })
+    .receive("ok", resp => { console.log("Joined successfully", resp); onJoin(resp) })
     .receive("error", resp => { console.log("Unable to join", resp) })
 
 // chat room
@@ -50,6 +56,8 @@ import {Socket, Presence} from "phoenix"
 
 // starting games
 
+  let startGameUI = () => gameArea.classList.add("active");
+  
   let startGameButton = document.getElementById("game-toggle");
 
   startGameButton.addEventListener('click', ()=> {
@@ -57,7 +65,7 @@ import {Socket, Presence} from "phoenix"
   })
 
   let gameArea = document.querySelector('.game-area');
-  channel.on("game:start", message => gameArea.classList.add("active"));
+  channel.on("game:start", startGameUI);
 
 // user list (w/ presence)
 


### PR DESCRIPTION
# Goals

Preserve our gameplay data even through a process crash

# Implementation

Adds a wrapper class around every gameplay GenServer that creates an ETS table for the gameplay process to persist to. On process crash, it restarts the gameplay process reloads state from the ets_table.

# For Discussion

Had to make the ETS table public writable -- which isn't great. Would be good to setup a mechanism for giving away control of the process to the gameplay